### PR TITLE
feat(rust): compile all members of the workspace

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -13,7 +13,7 @@
   name: check rust
   description: Check the package for errors.
   entry: cargo check
-  args: ["--all-targets", "--all-features"]
+  args: ["--all-targets", "--all-features", "--all", "--", "-D", "warnings"]
   language: system
   types: [rust]
   pass_filenames: false
@@ -22,14 +22,14 @@
   description: Lint rust sources
   entry: cargo clippy
   language: system
-  args: ["--all-targets", "--all-features", "--", "-D", "warnings"]
+  args: ["--all-targets", "--all-features", "--all", "--", "-D", "warnings"]
   types: [rust]
   pass_filenames: false
 - id: rust-doc
   name: rust docs
   description: Build the documentation
   entry: env RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo doc
-  args: ["--no-deps", "--all-features", "--"]
+  args: ["--no-deps", "--all-features", "--all"]
   types: ["rust"]
   language: system
   pass_filenames: false
@@ -37,7 +37,7 @@
   name: check all features
   description: Use cargo-hack to check all features with clippy
   entry: cargo hack
-  args: ["--feature-powerset", "check"]
+  args: ["--feature-powerset", "--all", "check"]
   types: [rust]
   language: system
   pass_filenames: false
@@ -46,7 +46,7 @@
   name: test rust
   description: Run the project test suite
   entry: cargo test
-  args: ["--all-targets", "--all-features"]
+  args: ["--all-targets", "--all-features", "--all"]
   language: system
   types: [rust]
   pass_filenames: false
@@ -54,7 +54,7 @@
   name: test rust doc
   description: Run the project test suite
   entry: cargo test --doc
-  args: ["--all-features"]
+  args: ["--all-features", "--all"]
   language: system
   types: [rust]
   pass_filenames: false
@@ -62,6 +62,7 @@
   name: build rust
   description: Build the project
   entry: cargo build
+  args: ["--all-features", "--all-targets", "--all"]
   language: system
   types: [rust]
   pass_filenames: false


### PR DESCRIPTION
If the crate is a workspace with a main package, cargo will not check all the members unless the `--all` flag is passed.