### PR TITLE
fix(nixfmt): use better args

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -159,7 +159,9 @@
 - id: nix-nixfmt
   name: format nix nixfmt
   description: Format nix package with nixfmt
-  entry: nixfmt --check
+  entry: nixfmt
+  args:
+    - "--verify"
   language: system
   types: [nix]
   pass_filenames: true


### PR DESCRIPTION
Format the files instead of checking them, also add the --verify flag